### PR TITLE
Fix import-time chrome crash; add jstorm/testing harness (#64)

### DIFF
--- a/src/chrome/local/index.ts
+++ b/src/chrome/local/index.ts
@@ -2,6 +2,11 @@ import * as base from "../..";
 import { StorageArea } from "../../interface";
 
 export class Model extends base.Model {
-    static override _area_: StorageArea = chrome.storage.local;
+    // Guard the global `chrome` reference the same way the base class does
+    // (src/model/index.ts), so that merely importing this sub-package outside
+    // an extension (node/jsdom) does not throw `ReferenceError: chrome is not
+    // defined` at module-evaluation time. The area is resolved lazily at each
+    // operation via Model.__area__(); see base class.
+    static override _area_: StorageArea = (typeof chrome == "undefined" ? null : chrome.storage?.local);
 }
 export { Types } from "../../types";

--- a/src/chrome/sync/index.ts
+++ b/src/chrome/sync/index.ts
@@ -2,6 +2,11 @@ import * as base from "../..";
 import { StorageArea } from "../../interface";
 
 export class Model extends base.Model {
-    static override _area_: StorageArea = chrome.storage.sync;
+    // Guard the global `chrome` reference the same way the base class does
+    // (src/model/index.ts), so that merely importing this sub-package outside
+    // an extension (node/jsdom) does not throw `ReferenceError: chrome is not
+    // defined` at module-evaluation time. The area is resolved lazily at each
+    // operation via Model.__area__(); see base class.
+    static override _area_: StorageArea = (typeof chrome == "undefined" ? null : chrome.storage?.sync);
 }
 export { Types } from "../../types";

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -11,6 +11,7 @@ type ModelConstructor<T> = {
     _area_: StorageArea;
 
     __ns__(): string;
+    __area__(): StorageArea;
     __rawdict__(): { [key: string]: any };
     _nextID_(ensemble?: { [key: string]: any }): string;
 
@@ -114,12 +115,31 @@ export class Model extends IDProvider {
      */
     static async __rawdict__<T>(this: ModelConstructor<T>): Promise<{ [key: string]: any }> {
         const namespace: string = this.__ns__();
-        const ensemble = await this._area_.get(namespace);
+        const ensemble = await this.__area__().get(namespace);
         return Object.keys(ensemble?.[namespace] || {}).length != 0 ? ensemble[namespace] : (this.default || {});
     }
 
     static useStorage(area: StorageArea) {
         this._area_ = area;
+    }
+
+    /**
+     * @private Strictly internal
+     * Resolve the configured StorageArea at call time (not at import time).
+     * This is the single runtime point where the storage backend is required:
+     * importing a Model never depends on a global `chrome` being present, and
+     * operating without a configured area fails with an actionable message
+     * instead of a cryptic `Cannot read properties of null (reading 'get')`.
+     */
+    static __area__<T>(this: ModelConstructor<T>): StorageArea {
+        const area = this._area_;
+        if (!area) {
+            throw new Error(
+                "jstorm: no StorageArea configured. " +
+                "Call Model.useStorage(...) or run in an extension context."
+            );
+        }
+        return area;
     }
 
     static new<T>(this: ModelConstructor<T>, props?: Record<string, any>, _id?: string): T {
@@ -160,7 +180,7 @@ export class Model extends IDProvider {
     }
 
     static async drop<T>(this: ModelConstructor<T>): Promise<void> {
-        await this._area_.set({ [this.__ns__()]: {} });
+        await this.__area__().set({ [this.__ns__()]: {} });
         return;
     }
 
@@ -171,7 +191,7 @@ export class Model extends IDProvider {
         const dict = await parent.__rawdict__();
         if (!this._id) this._id = parent._nextID_(dict);
         dict[this._id!] = this.__volatilize__();
-        await parent._area_.set({ [parent.__ns__()]: dict });
+        await parent.__area__().set({ [parent.__ns__()]: dict });
         return this;
     }
 
@@ -179,7 +199,7 @@ export class Model extends IDProvider {
         const parent = (this.constructor as ModelConstructor<T>);
         const dict = await parent.__rawdict__();
         delete dict[this._id];
-        await parent._area_.set({ [parent.__ns__()]: dict });
+        await parent.__area__().set({ [parent.__ns__()]: dict });
         delete this._id;
         return this;
     }

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,121 @@
+import type { StorageArea } from "../interface";
+
+/**
+ * jstorm/testing
+ *
+ * Test helpers for exercising Model logic outside an extension (node/jsdom)
+ * without hand-rolling a `chrome` mock. `MemoryStorageArea` mirrors the async
+ * `chrome.storage.StorageArea` shape, so tests run the same `await` path as
+ * production `chrome.storage`.
+ *
+ *     import { Model } from "jstorm/chrome/local";
+ *     import { installMemoryStorage } from "jstorm/testing";
+ *
+ *     beforeEach(() => Model.useStorage(installMemoryStorage()));
+ */
+
+type Dict = { [key: string]: any };
+
+/**
+ * Deep clone via JSON, matching how `chrome.storage` (and jstorm's WebStorage
+ * polyfill) serialize values. This isolates stored data from later mutations of
+ * the caller's objects, just like the real backend does.
+ */
+function clone<T>(value: T): T {
+    return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * MemoryStorageArea
+ * An in-memory test double with the same async surface jstorm uses on
+ * `chrome.storage.StorageArea`. Every operation returns a Promise.
+ *
+ * Mirrors `chrome.storage` `get` semantics:
+ *   - get() / get(null)      -> all items
+ *   - get("key")             -> { key: value } (key omitted when absent)
+ *   - get(["a", "b"])        -> projection (absent keys omitted)
+ *   - get({ a: 1, b: 2 })    -> stored value, or the given default when absent
+ */
+export class MemoryStorageArea {
+
+    private data: Dict;
+
+    constructor(seed: Dict = {}) {
+        this.data = clone(seed) || {};
+    }
+
+    async get(keys?: string | string[] | Dict | null): Promise<Dict> {
+        if (keys === undefined || keys === null) return clone(this.data);
+        const out: Dict = {};
+        if (typeof keys === "string") {
+            if (keys in this.data) out[keys] = clone(this.data[keys]);
+        } else if (Array.isArray(keys)) {
+            keys.forEach(key => { if (key in this.data) out[key] = clone(this.data[key]); });
+        } else {
+            Object.keys(keys).forEach(key => {
+                out[key] = (key in this.data) ? clone(this.data[key]) : clone(keys[key]);
+            });
+        }
+        return out;
+    }
+
+    async set(items: Dict): Promise<void> {
+        Object.assign(this.data, clone(items));
+    }
+
+    async remove(keys: string | string[]): Promise<void> {
+        (Array.isArray(keys) ? keys : [keys]).forEach(key => { delete this.data[key]; });
+    }
+
+    async clear(): Promise<void> {
+        this.data = {};
+    }
+
+    async getKeys(): Promise<string[]> {
+        return Object.keys(this.data);
+    }
+}
+
+/**
+ * installMemoryStorage
+ * Create a fresh in-memory StorageArea, optionally seeded. Designed to be
+ * dropped straight into `Model.useStorage`:
+ *
+ *     Model.useStorage(installMemoryStorage());
+ *     Model.useStorage(installMemoryStorage({ Player: { "1": { name: "Jack" } } }));
+ *
+ * To reset between tests, install a fresh one (or call `area.clear()`).
+ */
+export function installMemoryStorage(seed: Dict = {}): StorageArea {
+    return new MemoryStorageArea(seed) as unknown as StorageArea;
+}
+
+/** Minimal structural view of a Model class: enough to swap its storage area. */
+interface StorageHost {
+    _area_: StorageArea;
+    useStorage(area: StorageArea): void;
+}
+
+/**
+ * withStorage
+ * Run `fn` with `model` temporarily bound to `area`, restoring the previous
+ * area afterwards (even if `fn` throws). Keeps parallel/sequential tests from
+ * leaking a swapped storage backend into one another.
+ *
+ *     await withStorage(Player, installMemoryStorage(), async () => {
+ *         await Player.create({ name: "Jack" });
+ *     });
+ */
+export async function withStorage<T>(
+    model: StorageHost,
+    area: StorageArea,
+    fn: () => Promise<T> | T,
+): Promise<T> {
+    const previous = model._area_;
+    model.useStorage(area);
+    try {
+        return await fn();
+    } finally {
+        model.useStorage(previous);
+    }
+}

--- a/tests/storage-area.spec.ts
+++ b/tests/storage-area.spec.ts
@@ -1,0 +1,190 @@
+/// <reference path="../node_modules/@types/chrome/index.d.ts" />
+
+import { Model } from "../src/model";
+import { MemoryStorageArea, installMemoryStorage, withStorage } from "../src/testing";
+
+/**
+ * Regression + contract suite for jstorm Issue #64:
+ *   - importing `jstorm/chrome/*` outside an extension must not crash
+ *   - operating without a configured area must fail with an actionable message
+ *   - the in-memory test double must match the `chrome.storage.StorageArea` contract
+ *
+ * NOTE: jest.setup.ts installs `global.chrome` (storage.local only), so tests
+ * that need a "no chrome" world delete it inside an isolated module registry
+ * and restore it afterwards.
+ */
+
+describe("Issue #64 — import-time chrome guard", () => {
+
+    // AC-1: import without `chrome` must not throw `ReferenceError`.
+    it("AC-1: importing chrome/local & chrome/sync with chrome undefined does not throw", () => {
+        const saved = (globalThis as any).chrome;
+        delete (globalThis as any).chrome;
+        try {
+            expect(() => {
+                jest.isolateModules(() => {
+                    require("../src/chrome/local");
+                    require("../src/chrome/sync");
+                });
+            }).not.toThrow();
+        } finally {
+            (globalThis as any).chrome = saved;
+        }
+    });
+
+    // AC-3: inside an extension context, the sub-packages still resolve to the
+    // matching chrome.storage area (no regression).
+    it("AC-3: chrome/local resolves to chrome.storage.local when chrome is present", () => {
+        let area: any;
+        jest.isolateModules(() => {
+            area = require("../src/chrome/local").Model._area_;
+        });
+        expect(area).toBe(chrome.storage.local);
+    });
+
+    it("AC-3: chrome/sync resolves to chrome.storage.sync when chrome is present", () => {
+        const sync = { __isSyncStub__: true };
+        (chrome.storage as any).sync = sync;
+        try {
+            let area: any;
+            jest.isolateModules(() => {
+                area = require("../src/chrome/sync").Model._area_;
+            });
+            expect(area).toBe(sync);
+        } finally {
+            delete (chrome.storage as any).sync;
+        }
+    });
+});
+
+describe("Issue #64 — actionable error when unconfigured", () => {
+
+    // AC-2: operating with no area throws a readable message, not a null deref.
+    it("AC-2: find() without a configured area throws an actionable error", async () => {
+        class Unconfigured extends Model {}
+        Unconfigured.useStorage(null as any);
+        await expect(Unconfigured.find("anything")).rejects.toThrow(
+            /jstorm: no StorageArea configured/,
+        );
+    });
+
+    it("AC-2: save() without a configured area throws an actionable error", async () => {
+        class Unconfigured2 extends Model { public name: string; }
+        Unconfigured2.useStorage(null as any);
+        await expect(Unconfigured2.new({ name: "x" }).save()).rejects.toThrow(
+            /Call Model\.useStorage\(\.\.\.\)/,
+        );
+    });
+});
+
+describe("Issue #64 — 1-line in-memory swap (AC-4)", () => {
+
+    it("AC-4: Model.useStorage(installMemoryStorage()) runs the async chrome-like path", async () => {
+        class Town extends Model { public name: string; }
+        Town.useStorage(installMemoryStorage());
+
+        const t = await Town.create({ name: "Springfield" });
+        expect(t._id).not.toBeNull();
+
+        const found = await Town.find(t._id!);
+        expect(found?.name).toBe("Springfield");
+
+        expect(await Town.list()).toHaveLength(1);
+    });
+
+    it("AC-4: installMemoryStorage(seed) pre-populates records", async () => {
+        class Seeded extends Model {
+            static override _namespace_ = "Seeded";
+            public name: string;
+        }
+        Seeded.useStorage(installMemoryStorage({ Seeded: { "1": { name: "Jack" } } }));
+        const found = await Seeded.find("1");
+        expect(found?.name).toBe("Jack");
+    });
+
+    it("AC-4: withStorage scopes the swap and restores the previous area", async () => {
+        class City extends Model { public name: string; }
+        const before = (City as any)._area_;
+        await withStorage(City as any, installMemoryStorage(), async () => {
+            await City.create({ name: "Gotham" });
+            expect(await City.list()).toHaveLength(1);
+        });
+        expect((City as any)._area_).toBe(before);
+    });
+});
+
+describe("Issue #64 — MemoryStorageArea ↔ chrome.storage contract (AC-5)", () => {
+
+    let area: MemoryStorageArea;
+    beforeEach(() => { area = new MemoryStorageArea(); });
+
+    it("get() and get(null) return all items", async () => {
+        await area.set({ a: 1, b: 2 });
+        expect(await area.get()).toEqual({ a: 1, b: 2 });
+        expect(await area.get(null)).toEqual({ a: 1, b: 2 });
+    });
+
+    it("get(string) returns {key: value}; absent key is omitted", async () => {
+        await area.set({ a: 1 });
+        expect(await area.get("a")).toEqual({ a: 1 });
+        expect(await area.get("missing")).toEqual({});
+    });
+
+    it("get(array) projects requested keys; absent keys omitted", async () => {
+        await area.set({ a: 1, b: 2, c: 3 });
+        expect(await area.get(["a", "c", "nope"])).toEqual({ a: 1, c: 3 });
+    });
+
+    it("get(object) applies defaults for absent keys", async () => {
+        await area.set({ a: 1 });
+        expect(await area.get({ a: 0, b: 9 })).toEqual({ a: 1, b: 9 });
+    });
+
+    it("set merges, remove deletes (string & array), clear empties", async () => {
+        await area.set({ a: 1, b: 2 });
+        await area.set({ b: 3, c: 4 });
+        expect(await area.get(null)).toEqual({ a: 1, b: 3, c: 4 });
+        await area.remove("a");
+        expect(await area.get(null)).toEqual({ b: 3, c: 4 });
+        await area.remove(["b", "c"]);
+        expect(await area.get(null)).toEqual({});
+        await area.set({ x: 1 });
+        await area.clear();
+        expect(await area.get(null)).toEqual({});
+    });
+
+    it("preserves value types and deep-clones (no reference leakage)", async () => {
+        const nested = { n: 1, arr: [1, 2], o: { k: "v" } };
+        await area.set({ d: nested });
+        nested.n = 999;
+        nested.arr.push(3);
+        const got = await area.get("d");
+        expect(got.d).toEqual({ n: 1, arr: [1, 2], o: { k: "v" } });
+        expect(typeof got.d.n).toBe("number");
+    });
+
+    it("every operation returns a Promise (same await path as production)", () => {
+        expect(area.get(null)).toBeInstanceOf(Promise);
+        expect(area.set({ a: 1 })).toBeInstanceOf(Promise);
+        expect(area.remove("a")).toBeInstanceOf(Promise);
+        expect(area.clear()).toBeInstanceOf(Promise);
+    });
+
+    // Parity on the exact access path jstorm uses (get(namespaceString)), against
+    // the repository's built-in chrome.storage mock. The mock is intentionally
+    // minimal (it does not implement get(null)=all), which is itself why a
+    // dedicated, contract-tested double is needed — see Issue #64.
+    it("matches the chrome.storage mock on jstorm's get(namespace) path", async () => {
+        await chrome.storage.local.clear();
+        const payload = { Player: { "1": { name: "Jack", age: 17 } } };
+        await chrome.storage.local.set(payload);
+        const mem = new MemoryStorageArea();
+        await mem.set(payload);
+
+        const fromMock = await chrome.storage.local.get("Player");
+        const fromMem = await mem.get("Player");
+
+        expect(fromMem.Player).toEqual(payload.Player);
+        expect(fromMem.Player).toEqual(fromMock.Player);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
         "src/browser/local/index.ts",
         "src/browser/session/index.ts",
         "src/runtime/node/index.ts",
+        "src/testing/index.ts",
     ],
     "exclude": [
         "node_modules"


### PR DESCRIPTION
Closes #64

## Overview

Fixes the crash where merely **importing** a Model that extends `jstorm/chrome/local` (or `jstorm/chrome/sync`) from node/jsdom fails at module-evaluation time with `ReferenceError: chrome is not defined`, and adds an official seam (`jstorm/testing`) for unit-testing the Model layer outside an extension.

The root cause: the base class `src/model/index.ts` guards its global `chrome` reference with `typeof chrome`, but the convenience subclasses `chrome/local` / `chrome/sync` **grabbed it unguarded again** (the policy removed in `fd72b8f` was reintroduced by `aecd958` "Fix sub-packages").

## Changes (mapped to Issue #64 proposals 1–5)

- **1. Unify the import guard** — align the `_area_` initializer in `src/chrome/local/index.ts` / `src/chrome/sync/index.ts` with the base, `(typeof chrome == "undefined" ? null : chrome.storage?.local|sync)`, removing the import-time crash.
- **2. Lazy resolution + actionable error** — add an internal seam `__area__()` in `src/model/index.ts` and route every storage operation (`__rawdict__` / `drop` / `save` / `delete`) through it. When unconfigured it throws `jstorm: no StorageArea configured. Call Model.useStorage(...) or run in an extension context.` (avoiding the cryptic `null.get` deref).
- **3. Async in-memory double** — add `MemoryStorageArea` in `src/testing/index.ts`. It satisfies the async `chrome.storage.StorageArea` contract (`get`/`set`/`remove`/`clear`/`getKeys` return Promises; `get(null)` = all, array = projection, object = defaults) and uses JSON deep-clone to prevent reference leakage.
- **4. One-call harness** — expose `installMemoryStorage(seed?)` (one-line swap via `Model.useStorage(installMemoryStorage())`) and `withStorage(model, area, fn)` (scoped restore) from `jstorm/testing`. Promotes `useStorage` to an official seam.
- **5. Contract test** — `tests/storage-area.spec.ts` runs the chrome.storage contract suite against `MemoryStorageArea`, and verifies parity with the repository's built-in chrome mock on jstorm's actual access path (`get(namespace)`).

`src/testing/index.ts` is added to `tsconfig.json` `files` so that `make release` ships the compiled `lib/testing/index.js`. No new production dependency (zero-dependency preserved).

## Acceptance criteria (mirrors Issue #64 / verified locally)

- [x] AC-1 [LOGIC] In a node env with `chrome` undefined, importing `jstorm/chrome/local` / `jstorm/chrome/sync` does not throw `ReferenceError`
- [x] AC-2 [LOGIC] Calling `find()` / `save()` etc. with an unconfigured `_area_` throws an actionable message containing `jstorm: no StorageArea configured.`
- [x] AC-3 [LOGIC] When `chrome.storage` is defined, resolution stays `chrome/local`→`chrome.storage.local`, `chrome/sync`→`chrome.storage.sync` (no regression)
- [x] AC-4 [LOGIC] One line (`Model.useStorage(installMemoryStorage())`) swaps to in-memory; `create`/`find`/`list` run over the async path. `withStorage` also guarantees restore
- [x] AC-5 [LOGIC] `MemoryStorageArea` satisfies the chrome.storage contract (`get(null)` = all, missing-key return, type preservation) and matches the mock on the real access path
- [x] AC-6 [BUILD] `pnpm run build:lib` completes without error (confirmed `lib/testing/index.js` + `.d.ts` emitted)
- [x] AC-7 [LOGIC] `pnpm test` all pass (29 passed / 2 pre-existing skips) and `pnpm run e2e` still PASSes (exit 0)

## Verification log (local)

```
$ pnpm run build:lib      # AC-6 → exit 0
$ pnpm test               # AC-1..AC-5, AC-7(unit) → 3 suites, 29 passed, 2 skipped
$ pnpm run e2e            # AC-7(extension) → [0] Basic usage OK / [1] Salvage test OK, exit 0
```

> Note: this branch was produced by `/yolo #64`, running grill→tackle→uat autonomously with no human gates. Decisions taken unilaterally are listed in the "Critical Points of Review" (in the chat / PR comment).
